### PR TITLE
feat: add Spanish translations for server and panel messages

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -1,4 +1,9 @@
-# Quick Start OpenMU
+# Quick Start OpenMU / Guía Rápida OpenMU
+
+*Read this QuickStart in [English](#english) or [Español](#espanol).*
+
+<a id="english"></a>
+## English
 
 General requirements:
 
@@ -143,3 +148,125 @@ Season 6 only:
 * socket: Test account with socket item sets, level 380 characters
 
 The __passwords__ of these accounts are the __same as the user name__.
+
+<a id="espanol"></a>
+## Español
+
+Requisitos generales:
+
+* Puertos TCP libres:
+  * 80 (admin panel)
+  * 55901 - 55906 (game servers)
+  * 44405 - 44406 (connect servers)
+    * 44405: default connection port for the original client
+    * 44406: connection port especially for the [open source client](https://github.com/sven-n/MuMain)
+  * 55980 (chat server)
+
+* Un game client (revisa las FAQs de [nuestro Discord](https://discord.gg/2u5Agkd))
+* Conocimiento o forma de iniciar el game client para que se conecte al server. Nuestro Launcher lo hará.
+
+  * Binarios del Launcher: [MUnique.OpenMU.ClientLauncher v0.9.6.zip](https://github.com/MUnique/OpenMU/releases/download/v0.9.0/MUnique.OpenMU.ClientLauncher_0.9.6.zip)
+    * Requiere el [.NET 9 runtime](https://dotnet.microsoft.com/download/dotnet/9.0)
+  * Si tu server y client corren en tu host local, usa cualquier IP de 127.x.x.x, excepto 127.0.0.1, porque el client la bloquea. Por ejemplo, podrías usar 127.127.127.127
+
+Esta guía describe dos maneras de iniciar el server. Usa Docker si solo quieres probar. Si quieres desarrollar o depurar el server, elige la forma manual.
+
+Como puedes ver en los puertos del connect server, el server se inicializa para dos clients diferentes por defecto.
+Pueden conectarse a los mismos game servers a través de distintos puertos. Sin embargo, si te conectas al puerto incorrecto,
+quizás actualmente todavía funcione correctamente y solo obtendrás advertencias en los logs. Sin embargo, tan pronto como
+cambiemos las claves o métodos de encriptación, esto cambiará.
+
+## Docker
+
+Por favor, revisa la carpeta deploy de este proyecto. Allí encontrarás una guía más detallada sobre cómo configurar este proyecto.
+
+### Variables de entorno
+
+Es posible definir variables de entorno adicionales para influir en las cadenas de conexión de la base de datos postgres.
+
+| Nombre | Descripción |
+|-------|-------------|
+| DB_HOST | El hostname de la base de datos. Si el archivo de configuración local aún está configurado para usar 'localhost', el valor de esta variable lo reemplaza |
+| DB_ADMIN_USER | El nombre de usuario de la cuenta admin de postgres. Si el archivo de configuración local aún está configurado para usar 'postgres' como nombre de usuario del admin (primer entrada en ConnectionSettings.xml), el valor de esta variable lo reemplaza. |
+| DB_ADMIN_PW | La contraseña de la cuenta admin de postgres. Si el archivo de configuración local aún está configurado para usar 'admin' para la contraseña del admin (primer entrada en ConnectionSettings.xml), el valor de esta variable lo reemplaza. |
+
+## Manualmente
+
+Usa este método si quieres desarrollar o depurar OpenMU.
+
+Requisitos:
+
+* Windows OS, 10 o superior
+
+  * También se ejecuta en Linux y MacOS. Sin embargo, esta guía lo describe para Windows.
+
+  * PostgreSQL instalado
+
+  * Visual Studio 2022 (17.12+) instalado, con workloads para ASP.NET Web development y .NET Desktop development. Manténlo actualizado para evitar problemas.
+
+  * Extensión de Visual Studio "Web Compiler 2022+" si planeas editar archivos SCSS para el admin panel.
+    * https://marketplace.visualstudio.com/items?itemName=Failwyn.WebCompiler64
+
+  * [.NET SDK 9](https://dotnet.microsoft.com/download/dotnet/9.0) (debería estar incluido en Visual Studio 17.12+)
+    * `winget install Microsoft.DotNet.SDK.9`
+
+  * [NodeJS 16+](https://nodejs.org) instalado
+    * `winget install OpenJS.NodeJS.LTS`
+
+  * Este repositorio clonado
+
+Si tienes eso, tendrás que:
+
+* Abrir la solución de OpenMU con Visual Studio
+
+* Click derecho en la solución y 'Restore NuGet Packages'
+
+* Editar OpenMU\Persistence\EntityFramework\ConnectionSettings.xml, para que las cadenas de conexión sean correctas; sin embargo, solo el usuario/contraseña de la primera y segunda cadena necesitan ser correctos. El server intentará crear los otros roles especificados por la configuración.
+
+* Build la solución
+
+* Iniciar MUnique.OpenMU.Startup
+
+  * Si es necesario, creará los esquemas de base de datos, los roles requeridos y dará permisos a estos roles.
+
+  * Opcional: puedes reinicializar la base de datos agregando un parámetro ```-reinit```.
+
+* Cuando el Admin Panel esté inicializado, ve a <http://localhost/>. Allí deberías ver tres game servers, el chat server y dos connect servers. Inicia los connect servers y al menos un game server.
+
+* Si actualizas a un estado más reciente de la rama master, podría ser necesario actualizar la base de datos y la configuración. Puedes encontrar actualizaciones en el admin panel.
+
+* Luego puedes conectarte al server a través del game client.
+
+## Pasos útiles (opcionales)
+
+* __Auto Start__: Si no quieres iniciar cada server listener después de iniciar el proceso, puedes activar "Auto Start"
+
+  * en el admin panel en ```Configuration -> System```,
+
+  * o con el parámetro de inicio ```-autostart```.
+
+* __Resolución de IP__: Si encuentras desconexiones después de seleccionar un server, lo más probable es una configuración incorrecta para el IP resolver. Puedes cambiarlo fácilmente desde el admin panel en ```Configuration -> System```. También puedes cambiar el ajuste proporcionando start parameters o environment parameters; sin embargo, solo lo recomiendo para usuarios experimentados. Mira este [Readme](src/Startup/Readme.md) para más información.
+
+* __Cambiar la versión del juego__: Si quieres jugar otra versión distinta de la season 6, puedes inicializar la base de datos con otra versión del juego. Puedes hacerlo también desde el admin panel en la página ```Setup```.
+
+## Cuentas de prueba
+
+Para probar algunas features del server, se crean cuentas de prueba automáticamente cuando se inicializa la base de datos.
+
+Estos son los user names:
+
+* test0 - test9: General test accounts, level 1 a 90, en pasos de 10 niveles
+
+Solo Season 6:
+* test300: General test account con level 300
+* test400: General test account con level 400, master characters
+* testgm: Test account de un game master
+* testgm2: Test account de un game master con personajes summoner y rage fighter
+* testunlock: Test account sin characters, pero classes desbloqueadas
+* quest1: Test account para las level 150 quests
+* quest2: Test account para las level 220 quests
+* quest3: Test account para las level 400 quests
+* ancient: Test account con ancient item sets, level 330 characters
+* socket: Test account con socket item sets, level 380 characters
+
+Los __passwords__ de estas cuentas son __los mismos que el user name__.

--- a/docs/GameMap.md
+++ b/docs/GameMap.md
@@ -1,4 +1,9 @@
-﻿# GameMap
+﻿# GameMap / Mapa del Juego
+
+*Read this document in [English](#english) or [Español](#espanol).* 
+
+<a id="english"></a>
+## English
 
 I want to give a quick description about how the [game map](../src/GameLogic/GameMap.cs),
 especially observing between players/npc works.
@@ -51,3 +56,55 @@ Instead of partitioning a map into buckets (where a lot of them are empty), we
 could try to use some other 2d index structures, like
 [R-trees](https://en.wikipedia.org/wiki/R-tree) or [B-Trees](https://en.wikipedia.org/wiki/B-tree)
 with [Z-Ordering](https://en.wikipedia.org/wiki/Z-order_curve).
+
+<a id="espanol"></a>
+## Español
+
+Quiero dar una rápida descripción de cómo funciona el [game map](../src/GameLogic/GameMap.cs),
+especialmente la observación entre players y npc.
+
+## AreaOfInterestManager
+
+Cada game map tiene un area of interest manager. Se encarga de las
+suscripciones a eventos entre objetos, en caso de que se agreguen, muevan o
+eliminen en el map.
+
+La implementación por defecto ([BucketAreaOfInterestManager](../src/GameLogic/BucketAreaOfInterestManager.cs))
+crea un BucketMap, que se describe abajo. Otras implementaciones más simples
+podrían ser posibles en el futuro para maps que probablemente estén vacíos o
+requieran que todos los objetos de un map conozcan a todos los demás objetos
+(por ejemplo, el Duel map).
+
+## BucketMap
+
+El [bucket map](../src/GameLogic/BucketMap{T}.cs) es básicamente una estructura
+de datos bidimensional. Dividimos el map de 256 x 256 coordenadas posibles en
+"[buckets](../src/GameLogic/Bucket{T}.cs)". Por ejemplo, cada bucket cubre
+8 x 8 coordenadas.
+
+Un player (u otros "observers") puede observar buckets para ser informado
+cuando objetos (otros players, npc, items dropped) entren o salgan de ese
+bucket. Cuando un player se mueve y entra en el rango de un bucket (definido
+por un "info range"), se suscribe a estos eventos de entrada/salida y agrega
+todos los objetos existentes de ese bucket a su view.
+
+Podrías preguntarte por qué introduje esta estructura y no simplemente usar una
+lista de objetos y comparar la distancia al moverse para decidir si un objeto
+debería enviarse (add/remove) al game client. Según sé, el server original
+funciona así y tiene mucho lag cuando hay muchos players (más de mil en castle
+siege) en el mismo map, todos moviéndose. Es un problema O(n²) donde n es el
+número de objetos en el mismo map, lo cual se vuelve complejo rápidamente.
+
+Con este concepto, la búsqueda solo ocurre cuando un player entra en un bucket
+nuevo, y entonces busca solo nuevos buckets en rango, no otros objetos
+individuales. Así no es tan complejo cuando tienes muchos objetos en tu map. Por
+supuesto, esto requiere un poco más de memoria y es más lento en maps vacíos,
+pero en mi opinión vale la pena; usualmente los game maps están llenos de
+monsters, players y muchos items dropped.
+
+## Otras ideas
+
+En lugar de dividir un map en buckets (donde muchos están vacíos), podríamos
+usar otras estructuras de índice 2D, como
+[R-trees](https://en.wikipedia.org/wiki/R-tree) o [B-Trees](https://en.wikipedia.org/wiki/B-tree)
+con [Z-Ordering](https://en.wikipedia.org/wiki/Z-order_curve).

--- a/docs/MasterSystem.md
+++ b/docs/MasterSystem.md
@@ -1,4 +1,9 @@
-﻿# Master System
+﻿# Master System / Sistema Maestro
+
+*Read this document in [English](#english) or [Español](#espanol).* 
+
+<a id="english"></a>
+## English
 
 ## What is it?
 
@@ -113,4 +118,107 @@ Some short notes about the client:
 ### Sending Master Skills (F3 53)
 
 * For code, see [UpdateMasterSkillsPlugIn](https://github.com/MUnique/OpenMU/tree/master/src/GameServer/RemoteView/Character/UpdateMasterSkillsPlugIn.cs).
+* Packet: [C2F353 - Master Skill List](Packets/C2-F3-53-MasterSkillList_by-server.md)
+
+<a id="espanol"></a>
+## Español
+
+## ¿Qué es?
+
+Cuando un personaje alcanza cierto level (usualmente level 400) y completa una
+quest, su character class cambia a una *master character class*. Esto desbloquea
+el *Master Skill Tree*, que permite distribuir points a master skills. Los points
+se otorgan por cada master level que el player alcanza (igual que antes, ganando
+experience).
+
+## Tipos de master skills
+
+Básicamente hay dos tipos de master skills en un skill tree:
+
+### Passive skills
+
+Cuando se aprenden, estas skills otorgan ciertos power-ups de forma pasiva. Por
+ejemplo, hay master skills para incrementar la máxima health o para aumentar el
+attack damage.
+
+### Active skills
+
+Al aprenderlas, estas skills aparecen en la skill list. La mayoría de este tipo
+reemplaza skills existentes. Las skills reemplazadas permanecen en segundo plano
+y no son visibles en el game client, pero su valor interno sigue aplicándose a
+la master skill. La master skill solo define cuánto damage o buff se agrega a la
+skill reemplazada.
+
+## Estructura del master skill tree
+
+El master skill tree consta de tres roots. Las skills se colocan en filas que
+definen el *rank* de una skill. Por defecto hay 5 ranks disponibles; sin embargo,
+el game client soporta hasta 9 ranks. Cada skill usualmente puede tener hasta 20
+levels, algunas solo 10; el client probablemente soporta más.
+
+Una skill puede depender de una skill del mismo rank o del rank previo del mismo
+root.
+
+Cada character class puede aprender diferentes skills, que a veces son exclusivas
+de la clase. Una skill puede estar disponible para múltiples character classes,
+pero la root y el rank de una skill siempre son los mismos para todas las
+character classes. La apariencia visual en el client puede diferir.
+
+## Requisitos para aprender una skill
+
+Para aprender una skill, el server (y el client) realiza las siguientes
+verificaciones:
+
+### Character class
+
+La skill debe estar definida para la clase del character.
+
+### Rank
+
+La skill debe estar en el primer rank o una skill del rank previo del mismo root
+debe estar al menos en level 10.
+
+### Required Skill
+
+Si la skill tiene required skills definidas (es opcional), estas skills deben
+estar al menos en level 10.
+
+## Client implementation
+
+Algunas notas breves sobre el client:
+
+* Existe un message para el master level, etc. (F3 50)
+  * Contiene health y mana. Si este packet no se envía, un master character
+    aparece sin health/mana.
+* Existe un message para las master skills aprendidas (F3 53)
+  * La información sobre cada skill contiene:
+    * Skill Number
+    * Skill Index
+      * Define dónde se ubica la skill en la interface del client
+      * Me pregunto por qué necesitan esto en el message, ya que el client ya
+        conoce el index de una skill
+      * Puede diferir entre character classes
+    * Current Level
+    * Valor de su efecto en el current level
+    * Valor de su efecto en el next level
+  * Incluso si no se aprendió ninguna skill, este message debe enviarse; de lo
+    contrario, puede contener la información master del master character jugado
+    anteriormente.
+
+## Server implementation
+
+### Adding Points
+
+* Para código, ver [AddMasterPointAction](https://github.com/MUnique/OpenMU/tree/master/src/GameLogic/PlayerActions/Character/AddMasterPointAction.cs).
+* Request Packet: [C1F352 - Add Master Skill Point](Packets/C1-F3-52-AddMasterSkillPoint_by-client.md)
+* Response Packet: [C1F352 - Master skill level update](Packets/C1-F3-52-MasterSkillLevelUpdate_by-server.md)
+
+### Sending Master Stats (F3 50)
+
+* Para código, ver [UpdateMasterStatsPlugIn](https://github.com/MUnique/OpenMU/tree/master/src/GameServer/RemoteView/Character/UpdateMasterStatsPlugIn.cs).
+* Request Packet: [C2F350 - Master Stats Update](Packets/C1-F3-50-MasterStatsUpdate_by-server.md)
+
+### Sending Master Skills (F3 53)
+
+* Para código, ver [UpdateMasterSkillsPlugIn](https://github.com/MUnique/OpenMU/tree/master/src/GameServer/RemoteView/Character/UpdateMasterSkillsPlugIn.cs).
 * Packet: [C2F353 - Master Skill List](Packets/C2-F3-53-MasterSkillList_by-server.md)

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,4 +1,9 @@
-﻿# Documentation
+﻿# Documentation / Documentación
+
+*Read this documentation in [English](#english) or [Español](#espanol).* 
+
+<a id="english"></a>
+## English
 
 This directory should contain all the (technical) documentation of the OpenMU
 project, including [packets descriptions](Packets/Readme.md), game mechanics
@@ -158,3 +163,169 @@ progress of the project. See also:
 
 * [Startup](https://github.com/MUnique/OpenMU/tree/master/src/Startup): It's the
   project for the executeable which puts every piece of the puzzle together
+
+<a id="espanol"></a>
+## Español
+
+Este directorio debe contener toda la documentación técnica de OpenMU,
+incluyendo [descripciones de packets](Packets/Readme.md), mecánicas del
+game y arquitectura de software.
+
+## ¿Por qué no usar la wiki?
+
+Pensamos que gran parte de la documentación (especialmente la de packets)
+se basa en el código. Por eso tiene sentido que toda la documentación
+técnica esté disponible junto al código, sin necesidad de la wiki.
+
+Sin embargo, documentación como la guía de usuario para poner en marcha el
+proyecto podría estar en la wiki.
+
+## Arquitectura del Game Server
+
+Descargo de responsabilidad (por [sven-n](https://github.com/sven-n)):
+*No es una arquitectura perfecta, si es que existe. Sin embargo, tiene
+sentido para este propósito como desarrollador de aplicaciones de negocio.
+Intenté hacerla flexible y espero que no sea demasiado complicada.*
+
+Para ver el panorama general, puedes mirar el
+[architecture overview](architecture%20overview.png).
+
+Existen interfaces para la interoperabilidad entre los diferentes
+"servers" o subsistemas en
+[MUnique.OpenMU.Interfaces](https://github.com/MUnique/OpenMU/tree/master/src/Interfaces).
+
+### Comunicación entre el game client y el server
+
+La comunicación de red entre el game client y el game server se realiza a
+través de la [Connection class](https://github.com/MUnique/OpenMU/tree/master/src/Network/Connection.cs).
+MUnique.OpenMU.Network contiene todo lo necesario para conectar desde y
+hacia un game server usando el protocolo de red de MU Online. También
+contiene las estructuras de mensaje en
+MUnique.OpenMU.Network.Packets.
+
+#### Client -> Server
+
+Cuando se reciben datos del game client, se redirigen a los packet
+handlers ubicados en el espacio de nombres
+MUnique.OpenMU.GameServer.MessageHandler. Cada handler implementa un
+IPacketHandlerPlugIn. Estos packet handlers analizan los data packets y
+luego llaman a las player actions en
+MUnique.OpenMU.GameLogic.PlayerActions, las cuales no deberían tener
+conocimiento de la estructura del packet ni del medio de comunicación.
+
+#### Server -> Client
+
+El envío de datos al game client se realiza mediante views
+(MUnique.OpenMU.GameServer.RemoteView). Estas views utilizan la Connection
+class para enviar los datos en el protocolo especificado. GameLogic no
+conoce este protocolo y solo trabaja con los
+[view interface plugins](https://github.com/MUnique/OpenMU/tree/master/src/GameLogic/Views/IViewPlugIn.cs).
+
+#### Beneficios de esta arquitectura
+
+Como puedes ver, GameLogic en sí no sabe cómo se desencadenan las player
+actions ni cómo luce la "view". En lugar de trabajar con la red, podría
+haber una implementación de
+[view plugins](https://github.com/MUnique/OpenMU/tree/master/src/GameLogic/Views/IViewPlugIn.cs)
+que literalmente sea una interfaz gráfica. En vez de llamar las player
+actions mediante packet handler plugins, una interfaz de usuario podría
+llamarlas. Así, este proyecto podría ser la base de un game client (no MU)
+que también pueda soportar multiplayer y co-op con los componentes de
+server existentes.
+
+Todos los plugins son configurables desde el AdminPanel. Pueden activarse
+o desactivarse para reemplazarlos por versiones extendidas o modificadas.
+También es posible ofrecer diferentes protocolos para trabajar en el mismo
+game world implementando múltiples views y packet handlers con atributos
+de versiones de client diferentes. Cada game server puede tener varios
+tcp listeners que se vinculan a puertos tcp separados para distintas
+versiones de client.
+
+### Acceso a datos
+
+El patrón de acceso es principalmente el siguiente:
+
+* Al iniciar el server, se carga la game configuration
+* Cuando un game client inicia sesión, se carga su account
+* Durante el game, los datos del account se guardan en puntos
+  específicos y en un intervalo de tiempo
+
+#### Objetivo de diseño
+
+Debería ser posible soportar múltiples bases de datos diferentes, incluso
+NoSQL, sin cambiar la game logic. Para ello no usamos SQL ni código
+específico de la base de datos en la game logic. Los patrones de acceso
+deben tenerlo en cuenta. En lugar de muchas llamadas individuales a
+diferentes repositories en la game logic, debería hacerse una gran
+llamada.
+
+Por ejemplo, si queremos usar una base de datos basada en documentos, un
+account podría ser un documento y la game configuration completa otro.
+
+#### Abstracciones
+
+Para lograr estos objetivos de diseño, la game logic (y otras partes) usan
+abstracciones, [Repositories](https://martinfowler.com/eaaCatalog/repository.html),
+para acceder a datos. Estas abstracciones se encuentran en el namespace
+MUnique.OpenMU.Persistence.
+
+Utilizamos un enfoque basado en contextos para acceder a los datos, por
+ejemplo, la
+[GameConfiguration](https://github.com/MUnique/OpenMU/tree/master/src/DataModel/Configuration/GameConfiguration.cs)
+se carga a través del
+[GameConfigurationRepository](https://github.com/MUnique/OpenMU/tree/master/src/Persistence/EntityFramework/GameConfigurationRepository.cs)
+mientras se "usa" un
+[context](https://github.com/MUnique/OpenMU/tree/master/src/Persistence/IContext.cs),
+y cada player conectado utiliza su propio
+[player context](https://github.com/MUnique/OpenMU/tree/master/src/Persistence/IPlayerContext.cs)
+para cargar su
+[Account](https://github.com/MUnique/OpenMU/tree/master/src/DataModel/Entities/Account.cs).
+Al guardar un account, guardamos su context, que se encarga de aplicar los
+cambios requeridos en la base de datos. Cuando se accede o se crean nuevos
+objetos persistentes, el
+[context](https://github.com/MUnique/OpenMU/tree/master/src/Persistence/IContext.cs)
+debe estar "en uso" en el hilo actual, porque la implementación del
+context puede necesitar rastrear estos objetos. Se encarga de muchas
+cosas, por ejemplo crear nuevos objetos. Los contexts pueden crearse con
+el
+[PersistenceContextProvider](https://github.com/MUnique/OpenMU/tree/master/src/Persistence/IPersistenceContextProvider.cs).
+
+#### Implementación actual y base de datos soportada
+
+Por el momento, la capa de persistencia está implementada por
+[MUnique.OpenMU.Persistence.EntityFramework](../src/Persistence/EntityFramework/Readme.md)
+que utiliza [Entity Framework Core](https://github.com/aspnet/EntityFrameworkCore)
+y [PostgreSQL](https://www.postgresql.org/) como base de datos.
+
+#### Futuro
+
+Debido a que el data model es bastante complicado (lo cual es necesario si
+la configuration debe ser tan flexible), un modelo relacional completo en
+una base de datos probablemente no sea lo mejor en términos de
+performance. Actualmente usamos una aproximación para cargar la game
+configuration o el account con una consulta grande y generada
+dinámicamente que nos da los datos como json. Sorprendentemente es rápido,
+ya que la consulta para cargar la compleja game configuration termina en
+aproximadamente 1.5 segundos.
+
+Si hubiera un problema en el futuro, podríamos mezclar tablas relacionales
+con columnas json o cambiar completamente a una base de datos basada en
+documentos (por ejemplo, RavenDB).
+
+### Más información
+
+* [Packets](Packets/Readme.md): Información sobre las estructuras de packet
+* [Master Skill System](MasterSystem.md): Descripción del master skill system
+* [GameMap](GameMap.md): Descripción de la implementación de GameMap
+* [Progress](Progress.md): Información sobre el progreso de implementación
+  de las features del proyecto. Ver también:
+  * [Normal skill progress](https://github.com/MUnique/OpenMU/projects/9)
+  * [Master skill progress](https://github.com/MUnique/OpenMU/projects/10)
+* [Admin Panel](https://github.com/MUnique/OpenMU/tree/master/src/Web/AdminPanel):
+  La user inferface del server
+* [Attribute System](https://github.com/MUnique/OpenMU/tree/master/src/AttributeSystem):
+  El cálculo de damage y los atributos de player se basan en él
+* [Network](https://github.com/MUnique/OpenMU/tree/master/src/Network): Sobre la
+  comunicación de red
+* [Startup](https://github.com/MUnique/OpenMU/tree/master/src/Startup): El
+  proyecto para el ejecutable que junta todas las piezas del rompecabezas

--- a/src/GameLogic/PlugIns/ChatCommands/ClearInventoryChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/ClearInventoryChatCommandPlugIn.cs
@@ -20,13 +20,13 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which clears a character's inventory.
 /// </summary>
 [Guid("1E895A6F-3056-4A78-BA64-96E24363B8BC")]
-[PlugIn("Clear Inventory chat command", "Clears inventory. Usage: /clearinv (optional:character)")]
-[ChatCommandHelp(Command, "Clears inventory.", null, MinimumStatus)]
+[PlugIn("Clear Inventory chat command", "Limpia el inventario. Uso: /clearinv (opcional:personaje)")]
+[ChatCommandHelp(Command, "Limpia el inventario.", null, MinimumStatus)]
 public class ClearInventoryChatCommandPlugIn : ChatCommandPlugInBase<ClearInventoryChatCommandPlugIn.Arguments>, ISupportCustomConfiguration<ClearInventoryChatCommandPlugIn.ClearInventoryConfiguration>, ISupportDefaultCustomConfiguration, IDisabledByDefault
 {
     private const string Command = "/clearinv";
     private const CharacterStatus MinimumStatus = CharacterStatus.Normal;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
     private const int ConfirmationTimeoutSeconds = 10;
     private readonly Dictionary<Guid, DateTime> pendingConfirmations = new();
 

--- a/src/GameLogic/PlugIns/ChatCommands/GetLevelChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/GetLevelChatCommandPlugIn.cs
@@ -15,14 +15,14 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin to get a character's level.
 /// </summary>
 [Guid("9D5C8FFE-EC32-48AC-8B6F-BB361AD184E5")]
-[PlugIn("Get level command", "Gets level of a player. Usage: /getlevel (optional:character)")]
-[ChatCommandHelp(Command, "Gets level of a player. Usage: /getlevel (optional:character)", null)]
+[PlugIn("Get level command", "Obtiene el nivel de un jugador. Uso: /getlevel (opcional:personaje)")]
+[ChatCommandHelp(Command, "Obtiene el nivel de un jugador. Uso: /getlevel (opcional:personaje)", null)]
 public class GetLevelChatCommandPlugIn : ChatCommandPlugInBase<GetLevelChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/getlevel";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string LevelGetMessage = "Level of '{0}': {1}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string LevelGetMessage = "Nivel de '{0}': {1}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/GetLevelUpPointsChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/GetLevelUpPointsChatCommandPlugIn.cs
@@ -14,14 +14,14 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin to get a character's level-up points.
 /// </summary>
 [Guid("E4D65354-CCD2-4960-BDCA-D4582A57BBCB")]
-[PlugIn("Get level up points command", "Gets level up points of a player. Usage: /getleveluppoints (optional:character)")]
-[ChatCommandHelp(Command, "Gets level up points of a player. Usage: /getleveluppoints (optional:character)", null)]
+[PlugIn("Get level up points command", "Obtiene los puntos de nivel de un jugador. Uso: /getleveluppoints (opcional:personaje)")]
+[ChatCommandHelp(Command, "Obtiene los puntos de nivel de un jugador. Uso: /getleveluppoints (opcional:personaje)", null)]
 public class GetLevelUpPointsChatCommandPlugIn : ChatCommandPlugInBase<GetLevelUpPointsChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/getleveluppoints";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string LevelUpPointsGetMessage = "Level-up points of '{0}': {1}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string LevelUpPointsGetMessage = "Puntos de nivel de '{0}': {1}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/GetMasterLevelChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/GetMasterLevelChatCommandPlugIn.cs
@@ -15,14 +15,14 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin to get a character's master level.
 /// </summary>
 [Guid("4CED4BF8-9D91-47F9-82DE-51E2646F77C8")]
-[PlugIn("Get master level command", "Gets master level of a player. Usage: /getmasterlevel (optional:character)")]
-[ChatCommandHelp(Command, "Gets master level of a player. Usage: /getmasterlevel (optional:character)", null)]
+[PlugIn("Get master level command", "Obtiene el nivel maestro de un jugador. Uso: /getmasterlevel (opcional:personaje)")]
+[ChatCommandHelp(Command, "Obtiene el nivel maestro de un jugador. Uso: /getmasterlevel (opcional:personaje)", null)]
 public class GetMasterLevelChatCommandPlugIn : ChatCommandPlugInBase<GetMasterLevelChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/getmasterlevel";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string MasterLevelGetMessage = "Master level of '{0}': {1}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string MasterLevelGetMessage = "Nivel maestro de '{0}': {1}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/GetMasterLevelUpPointsChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/GetMasterLevelUpPointsChatCommandPlugIn.cs
@@ -14,14 +14,14 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin to get a character's master level-up points.
 /// </summary>
 [Guid("8ACCF267-F5F3-4003-B4C3-536ACCB5181D")]
-[PlugIn("Get master level up points command", "Gets master level up points of a player. Usage: /getmasterleveluppoints (optional:character)")]
-[ChatCommandHelp(Command, "Gets master level up points of a player. Usage: /getmasterleveluppoints (optional:character)", null)]
+[PlugIn("Get master level up points command", "Obtiene los puntos de nivel maestro de un jugador. Uso: /getmasterleveluppoints (opcional:personaje)")]
+[ChatCommandHelp(Command, "Obtiene los puntos de nivel maestro de un jugador. Uso: /getmasterleveluppoints (opcional:personaje)", null)]
 public class GetMasterLevelUpPointsChatCommandPlugIn : ChatCommandPlugInBase<GetMasterLevelUpPointsChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/getmasterleveluppoints";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string MasterLevelUpPointsGetMessage = "Master level-up points of '{0}': {1}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string MasterLevelUpPointsGetMessage = "Puntos de nivel maestro de '{0}': {1}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/GetMoneyChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/GetMoneyChatCommandPlugIn.cs
@@ -14,14 +14,14 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin to get a character's money.
 /// </summary>
 [Guid("207F5872-33AB-4764-B67F-95AB7C6313E3")]
-[PlugIn("Get money command", "Gets money of a player. Usage: /getmoney (optional:character)")]
-[ChatCommandHelp(Command, "Gets money of a player. Usage: /getmoney (optional:character)", null)]
+[PlugIn("Get money command", "Obtiene el Zen de un jugador. Uso: /getmoney (opcional:personaje)")]
+[ChatCommandHelp(Command, "Obtiene el Zen de un jugador. Uso: /getmoney (opcional:personaje)", null)]
 public class GetMoneyChatCommandPlugIn : ChatCommandPlugInBase<GetMoneyChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/getmoney";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string MoneyGetMessage = "Money of '{0}': {1}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string MoneyGetMessage = "Zen de '{0}': {1}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/GetResetsChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/GetResetsChatCommandPlugIn.cs
@@ -15,15 +15,15 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's resets.
 /// </summary>
 [Guid("26ACF6A9-346A-49DF-8583-EA610F6E3AEA")]
-[PlugIn("Get resets command", "Gets resets of a player. Usage: /getresets (optional:character)")]
-[ChatCommandHelp(Command, "Gets resets of a player. Usage: /getresets (optional:character)", null)]
+[PlugIn("Get resets command", "Obtiene los resets de un jugador. Uso: /getresets (opcional:personaje)")]
+[ChatCommandHelp(Command, "Obtiene los resets de un jugador. Uso: /getresets (opcional:personaje)", null)]
 public class GetResetsChatCommandPlugIn : ChatCommandPlugInBase<GetResetsChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/getresets";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string ResetPluginDisabledMessage = "The reset system is not enabled on this server.";
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string ResetsGetMessage = "Resets of '{0}': {1}.";
+    private const string ResetPluginDisabledMessage = "El sistema de resets no está habilitado en este servidor.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string ResetsGetMessage = "Resets de '{0}': {1}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/NpcChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/NpcChatCommandPlugIn.cs
@@ -20,14 +20,14 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which opens NPC windows.
 /// </summary>
 [Guid("D8AC2F15-AB30-4432-A042-A41ACA1B274D")]
-[PlugIn("NPC open merchant chat command", "Opens the merchant NPC store.")]
-[ChatCommandHelp(Command, "Opens the NPC store.", null)]
+[PlugIn("NPC open merchant chat command", "Abre la tienda del NPC comerciante.")]
+[ChatCommandHelp(Command, "Abre la tienda del NPC.", null)]
 public class NpcChatCommandPlugIn : ChatCommandPlugInBase<NpcChatCommandPlugIn.Arguments>, ISupportCustomConfiguration<NpcChatCommandPlugIn.NpcChatCommandConfiguration>, ISupportDefaultCustomConfiguration, IDisabledByDefault
 {
     private const string Command = "/npc";
     private const CharacterStatus MinimumStatus = CharacterStatus.Normal;
-    private const string InvalidNpcIdMessage = "Invalid NPC ID \"{0}\". Please provide a valid merchant NPC ID.";
-    private const string InvalidMerchantMessage = "Not a valid merchant NPC.";
+    private const string InvalidNpcIdMessage = "ID de NPC \"{0}\" inválido. Por favor proporciona un ID de comerciante válido.";
+    private const string InvalidMerchantMessage = "NPC no es un comerciante válido.";
 
     private readonly TalkNpcAction _talkNpcAction = new();
 

--- a/src/GameLogic/PlugIns/ChatCommands/OpenWarehouseChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/OpenWarehouseChatCommandPlugIn.cs
@@ -19,13 +19,13 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which opens the warehouse NPC window.
 /// </summary>
 [Guid("62027B6B-D8E7-4DDB-A16B-7070D1BC4A56")]
-[PlugIn("Open Warehouse chat command", "Opens the warehouse.")]
-[ChatCommandHelp(Command, "Opens the warehouse.", null)]
+[PlugIn("Open Warehouse chat command", "Abre el baúl.")]
+[ChatCommandHelp(Command, "Abre el baúl.", null)]
 public class OpenWarehouseChatCommandPlugIn : ChatCommandPlugInBase<OpenWarehouseChatCommandPlugIn.Arguments>, ISupportCustomConfiguration<OpenWarehouseChatCommandPlugIn.OpenWarehouseChatCommandConfiguration>, ISupportDefaultCustomConfiguration, IDisabledByDefault
 {
     private const string Command = "/openware";
     private const CharacterStatus MinimumStatus = CharacterStatus.Normal;
-    private const string NoWarehouseNpcMessage = "No warehouse NPC found";
+    private const string NoWarehouseNpcMessage = "No se encontró NPC de baúl";
 
     private readonly TalkNpcAction _talkNpcAction = new();
 
@@ -95,6 +95,6 @@ public class OpenWarehouseChatCommandPlugIn : ChatCommandPlugInBase<OpenWarehous
         /// Gets or sets the message to show when the player does not have the required VIP level for this command (excluding GM).
         /// </summary>
         [Display(Name = "Insufficient VIP Level Message", Description = @"The message to show when the player does not have the required VIP level for this command (excluding GM).")]
-        public string InsufficientVipLevelMessage { get; set; } = "Insufficient VIP level to use this command";
+        public string InsufficientVipLevelMessage { get; set; } = "Nivel VIP insuficiente para usar este comando";
     }
 }

--- a/src/GameLogic/PlugIns/ChatCommands/SetLevelChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/SetLevelChatCommandPlugIn.cs
@@ -15,15 +15,15 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's level.
 /// </summary>
 [Guid("4BE779C9-E6B6-47F2-BC23-2E71D82A6C1D")]
-[PlugIn("Set level command", "Sets level of a player. Usage: /setlevel (level) (optional:character)")]
-[ChatCommandHelp(Command, "Sets level of a player. Usage: /setlevel (level) (optional:character)", null)]
+[PlugIn("Set level command", "Establece el nivel de un jugador. Uso: /setlevel (nivel) (opcional:personaje)")]
+[ChatCommandHelp(Command, "Establece el nivel de un jugador. Uso: /setlevel (nivel) (opcional:personaje)", null)]
 public class SetLevelChatCommandPlugIn : ChatCommandPlugInBase<SetLevelChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/setlevel";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string InvalidLevelMessage = "Invalid level - must be between 1 and {0}.";
-    private const string LevelSetMessage = "Level set to {0}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string InvalidLevelMessage = "Nivel inválido - debe estar entre 1 y {0}.";
+    private const string LevelSetMessage = "Nivel establecido en {0}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/SetLevelUpPointsChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/SetLevelUpPointsChatCommandPlugIn.cs
@@ -14,15 +14,15 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's level-up points.
 /// </summary>
 [Guid("50EF670A-DF7A-4FEE-8E42-7C7A18A68941")]
-[PlugIn("Set level up points command", "Sets level up points of a player. Usage: /setleveluppoints (points) (optional:character)")]
-[ChatCommandHelp(Command, "Sets level up points of a player. Usage: /setleveluppoints (points) (optional:character)", null)]
+[PlugIn("Set level up points command", "Establece los puntos de nivel de un jugador. Uso: /setleveluppoints (puntos) (opcional:personaje)")]
+[ChatCommandHelp(Command, "Establece los puntos de nivel de un jugador. Uso: /setleveluppoints (puntos) (opcional:personaje)", null)]
 public class SetLevelUpPointsChatCommandPlugIn : ChatCommandPlugInBase<SetLevelUpPointsChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/setleveluppoints";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string InvalidLevelUpPointsMessage = "Invalid level-up points - must be bigger or equal to 0.";
-    private const string LevelUpPointsSetMessage = "Level-up points set to {0}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string InvalidLevelUpPointsMessage = "Puntos de nivel inválidos - deben ser mayores o iguales a 0.";
+    private const string LevelUpPointsSetMessage = "Puntos de nivel establecidos en {0}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/SetMasterLevelChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/SetMasterLevelChatCommandPlugIn.cs
@@ -15,15 +15,15 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's master level.
 /// </summary>
 [Guid("E401CA16-7827-495B-9DD0-EABDFF39901E")]
-[PlugIn("Set master level command", "Sets master level of a player. Usage: /setmasterlevel (level) (optional:character)")]
-[ChatCommandHelp(Command, "Sets master level of a player. Usage: /setmasterlevel (level) (optional:character)", null)]
+[PlugIn("Set master level command", "Establece el nivel maestro de un jugador. Uso: /setmasterlevel (nivel) (opcional:personaje)")]
+[ChatCommandHelp(Command, "Establece el nivel maestro de un jugador. Uso: /setmasterlevel (nivel) (opcional:personaje)", null)]
 public class SetMasterLevelChatCommandPlugIn : ChatCommandPlugInBase<SetMasterLevelChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/setmasterlevel";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string InvalidLevelMessage = "Invalid level - must be between 1 and {0}.";
-    private const string MasterLevelSetMessage = "Master level set to {0}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string InvalidLevelMessage = "Nivel inválido - debe estar entre 1 y {0}.";
+    private const string MasterLevelSetMessage = "Nivel maestro establecido en {0}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/SetMasterLevelUpPointsChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/SetMasterLevelUpPointsChatCommandPlugIn.cs
@@ -14,15 +14,15 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's master level-up points.
 /// </summary>
 [Guid("69AC0B9E-1063-448E-ABD6-C5837A1E8A4B")]
-[PlugIn("Set master level up points command", "Sets master level up points of a player. Usage: /setmasterleveluppoints (points) (optional:character)")]
-[ChatCommandHelp(Command, "Sets master level up points of a player. Usage: /setmasterleveluppoints (points) (optional:character)", null)]
+[PlugIn("Set master level up points command", "Establece los puntos de nivel maestro de un jugador. Uso: /setmasterleveluppoints (puntos) (opcional:personaje)")]
+[ChatCommandHelp(Command, "Establece los puntos de nivel maestro de un jugador. Uso: /setmasterleveluppoints (puntos) (opcional:personaje)", null)]
 public class SetMasterLevelUpPointsChatCommandPlugIn : ChatCommandPlugInBase<SetMasterLevelUpPointsChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/setmasterleveluppoints";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string InvalidMasterLevelUpPointsMessage = "Invalid master level-up points - must be bigger or equal to 0.";
-    private const string MasterLevelUpPointsSetMessage = "Master level-up points set to {0}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string InvalidMasterLevelUpPointsMessage = "Puntos de nivel maestro inválidos - deben ser mayores o iguales a 0.";
+    private const string MasterLevelUpPointsSetMessage = "Puntos de nivel maestro establecidos en {0}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/SetMoneyChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/SetMoneyChatCommandPlugIn.cs
@@ -14,15 +14,15 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's money.
 /// </summary>
 [Guid("00AA4F0E-911D-49FE-8D88-114C7496D383")]
-[PlugIn("Set money command", "Sets money of a player. Usage: /setmoney (amount) (optional:character)")]
-[ChatCommandHelp(Command, "Sets money of a player. Usage: /setmoney (amount) (optional:character)", null)]
+[PlugIn("Set money command", "Establece el Zen de un jugador. Uso: /setmoney (cantidad) (opcional:personaje)")]
+[ChatCommandHelp(Command, "Establece el Zen de un jugador. Uso: /setmoney (cantidad) (opcional:personaje)", null)]
 public class SetMoneyChatCommandPlugIn : ChatCommandPlugInBase<SetMoneyChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/setmoney";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string InvalidAmountMessage = "Invalid amount - must be between 0 and {0}.";
-    private const string MoneySetMessage = "Money set to {0}.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string InvalidAmountMessage = "Cantidad inválida - debe estar entre 0 y {0}.";
+    private const string MoneySetMessage = "Zen establecido en {0}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/ChatCommands/SetResetsChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/SetResetsChatCommandPlugIn.cs
@@ -15,17 +15,17 @@ using MUnique.OpenMU.PlugIns;
 /// A chat command plugin which sets a character's resets.
 /// </summary>
 [Guid("47A8644C-B6C5-439E-BAB0-C1A7AE72691C")]
-[PlugIn("Set resets command", "Sets resets of a player. Usage: /setresets (resets) (optional:character)")]
-[ChatCommandHelp(Command, "Sets resets of a player. Usage: /setresets (resets) (optional:character)", null)]
+[PlugIn("Set resets command", "Establece los resets de un jugador. Uso: /setresets (resets) (opcional:personaje)")]
+[ChatCommandHelp(Command, "Establece los resets de un jugador. Uso: /setresets (resets) (opcional:personaje)", null)]
 public class SetResetsChatCommandPlugIn : ChatCommandPlugInBase<SetResetsChatCommandPlugIn.Arguments>, IDisabledByDefault
 {
     private const string Command = "/setresets";
     private const CharacterStatus MinimumStatus = CharacterStatus.GameMaster;
-    private const string ResetPluginDisabledMessage = "The reset system is not enabled on this server.";
-    private const string CharacterNotFoundMessage = "Character '{0}' not found.";
-    private const string InvalidResetsWithLimitMessage = "Invalid resets - must be between 0 and {0}.";
-    private const string InvalidResetsNoLimitMessage = "Invalid resets - must be bigger than 0.";
-    private const string ResetsSetMessage = "Resets set to {0}.";
+    private const string ResetPluginDisabledMessage = "El sistema de resets no está habilitado en este servidor.";
+    private const string CharacterNotFoundMessage = "Personaje '{0}' no encontrado.";
+    private const string InvalidResetsWithLimitMessage = "Resets inválidos - deben estar entre 0 y {0}.";
+    private const string InvalidResetsNoLimitMessage = "Resets inválidos - deben ser mayores que 0.";
+    private const string ResetsSetMessage = "Resets establecidos en {0}.";
 
     /// <inheritdoc />
     public override string Key => Command;

--- a/src/GameLogic/PlugIns/InvasionEvents/PeriodicInvasionConfiguration.cs
+++ b/src/GameLogic/PlugIns/InvasionEvents/PeriodicInvasionConfiguration.cs
@@ -17,7 +17,7 @@ public class PeriodicInvasionConfiguration : PeriodicTaskConfiguration
     /// </summary>
     public PeriodicInvasionConfiguration()
     {
-        this.Message = "Invasion's been started!";
+        this.Message = "¡La invasión ha comenzado!";
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class PeriodicInvasionConfiguration : PeriodicTaskConfiguration
     {
         TaskDuration = TimeSpan.FromMinutes(5),
         PreStartMessageDelay = TimeSpan.FromSeconds(3),
-        Message = "[{mapName}] Golden Invasion!",
+        Message = "[{mapName}] ¡Invasión Dorada!",
         Timetable = GenerateTimeSequence(TimeSpan.FromHours(4)).ToList(), // Every 4 hours
     };
 
@@ -38,7 +38,7 @@ public class PeriodicInvasionConfiguration : PeriodicTaskConfiguration
     {
         TaskDuration = TimeSpan.FromMinutes(10),
         PreStartMessageDelay = TimeSpan.FromSeconds(3),
-        Message = "[{mapName}] Red Dragon Invasion!",
+        Message = "[{mapName}] ¡Invasión del Dragón Rojo!",
         Timetable = GenerateTimeSequence(TimeSpan.FromHours(6), new TimeOnly(2, 0)).ToList(), // Every 6 hours, starting from 02:00
     };
 }

--- a/src/GameLogic/PlugIns/InvasionEvents/WhiteWizardInvasionPlugIn.cs
+++ b/src/GameLogic/PlugIns/InvasionEvents/WhiteWizardInvasionPlugIn.cs
@@ -45,7 +45,7 @@ public class WhiteWizardInvasionPlugIn : BaseInvasionPlugIn<WhiteWizardInvasionC
         // Typical White Wizard cadence can vary; default to every 4 hours.
         TaskDuration = TimeSpan.FromMinutes(10),
         PreStartMessageDelay = TimeSpan.FromSeconds(3),
-        Message = "[{mapName}] White Wizard Invasion!",
+        Message = "[{mapName}] ¡Invasión de White Wizard!",
         Timetable = WhiteWizardInvasionConfiguration.GenerateTimeSequence(TimeSpan.FromHours(4)).ToList(),
     };
 

--- a/src/GameLogic/PlugIns/PeriodicTasks/BloodCastleStartConfiguration.cs
+++ b/src/GameLogic/PlugIns/PeriodicTasks/BloodCastleStartConfiguration.cs
@@ -16,8 +16,8 @@ public class BloodCastleStartConfiguration : MiniGameStartConfiguration
         new()
         {
             PreStartMessageDelay = TimeSpan.Zero,
-            EntranceOpenedMessage = "Blood Castle entrance is open and closes in {0} minute(s).",
-            EntranceClosedMessage = "Blood Castle entrance closed.",
+            EntranceOpenedMessage = "La entrada de Blood Castle está abierta y cierra en {0} minuto(s).",
+            EntranceClosedMessage = "La entrada de Blood Castle se cerró.",
             TaskDuration = TimeSpan.FromMinutes(20),
             Timetable = GenerateTimeSequence(TimeSpan.FromMinutes(120)).ToList(),
         };

--- a/src/GameLogic/PlugIns/PeriodicTasks/ChaosCastleStartConfiguration.cs
+++ b/src/GameLogic/PlugIns/PeriodicTasks/ChaosCastleStartConfiguration.cs
@@ -16,8 +16,8 @@ public class ChaosCastleStartConfiguration : MiniGameStartConfiguration
         new()
         {
             PreStartMessageDelay = TimeSpan.Zero,
-            EntranceOpenedMessage = "Chaos Castle entrance is open and closes in {0} minute(s).",
-            EntranceClosedMessage = "Chaos Castle entrance closed.",
+            EntranceOpenedMessage = "La entrada de Chaos Castle está abierta y cierra en {0} minuto(s).",
+            EntranceClosedMessage = "La entrada de Chaos Castle se cerró.",
             TaskDuration = TimeSpan.FromMinutes(15),
             Timetable = PeriodicTaskConfiguration.GenerateTimeSequence(TimeSpan.FromMinutes(60)).ToList(),
         };

--- a/src/GameLogic/PlugIns/PeriodicTasks/DevilSquareStartConfiguration.cs
+++ b/src/GameLogic/PlugIns/PeriodicTasks/DevilSquareStartConfiguration.cs
@@ -16,8 +16,8 @@ public class DevilSquareStartConfiguration : MiniGameStartConfiguration
         new()
         {
             PreStartMessageDelay = TimeSpan.Zero,
-            EntranceOpenedMessage = "Devil Square entrance is open and closes in {0} minute(s).",
-            EntranceClosedMessage = "Devil Square entrance closed.",
+            EntranceOpenedMessage = "La entrada de Devil Square está abierta y cierra en {0} minuto(s).",
+            EntranceClosedMessage = "La entrada de Devil Square se cerró.",
             TaskDuration = TimeSpan.FromMinutes(25),
             Timetable = PeriodicTaskConfiguration.GenerateTimeSequence(TimeSpan.FromMinutes(240)).ToList(),
         };

--- a/src/GameLogic/PlugIns/PeriodicTasks/HappyHourConfiguration.cs
+++ b/src/GameLogic/PlugIns/PeriodicTasks/HappyHourConfiguration.cs
@@ -18,7 +18,7 @@ public class HappyHourConfiguration : PeriodicTaskConfiguration
     {
         TaskDuration = TimeSpan.FromHours(1),
         PreStartMessageDelay = TimeSpan.FromSeconds(0),
-        Message = "Happy Hour event has been started!",
+        Message = "¡El evento Happy Hour ha comenzado!",
         Timetable = GenerateTimeSequence(TimeSpan.FromHours(6), new TimeOnly(0, 5)).ToList(), // Every 6 hours,
         ExperienceMultiplier = 1.5f,
     };

--- a/src/GameLogic/PlugIns/ShowMessageToAllWhenPlayerEnteredWorldPlugIn.cs
+++ b/src/GameLogic/PlugIns/ShowMessageToAllWhenPlayerEnteredWorldPlugIn.cs
@@ -23,6 +23,6 @@ public class ShowMessageToAllWhenPlayerEnteredWorldPlugIn : IPlayerStateChangedP
             return;
         }
 
-        await player.GameContext.SendGlobalMessageAsync($"{selectedCharacter.Name} entered the game.", MessageType.BlueNormal).ConfigureAwait(false);
+        await player.GameContext.SendGlobalMessageAsync($"{selectedCharacter.Name} entró al juego.", MessageType.BlueNormal).ConfigureAwait(false);
     }
 }

--- a/src/GameLogic/PlugIns/UnlockCharacterClass/UnlockCharacterAtLevelBase.cs
+++ b/src/GameLogic/PlugIns/UnlockCharacterClass/UnlockCharacterAtLevelBase.cs
@@ -23,7 +23,7 @@ public abstract class UnlockCharacterAtLevelBase : ICharacterLevelUpPlugIn
     {
         this._classNumber = classNumber;
         this._minimumLevel = minimumLevel;
-        this._warningMessage = $"Couldn't unlock {className}, because it couldn't be found in the configuration.";
+        this._warningMessage = $"No se pudo desbloquear {className}, porque no se encontró en la configuración.";
     }
 
     /// <inheritdoc />

--- a/src/Web/AdminPanel/Components/ConnectServerConfiguration.razor
+++ b/src/Web/AdminPanel/Components/ConnectServerConfiguration.razor
@@ -3,41 +3,41 @@
 
 @if (this.Configuration is null)
 {
-    <span>Loading ...</span>
+    <span>Cargando ...</span>
 }
 else
 {
 <EditForm Model="@Configuration" OnValidSubmit="OnValidSubmit">
     <DataAnnotationsValidator/>
-    <TextField Id="descriptionInput" Label="Description" @bind-Value="@Configuration.Description"/>
-    <NumberField Id="clientListenerPortInput" Label="Client listener port" @bind-Value="@Configuration.ClientListenerPort"/>
+    <TextField Id="descriptionInput" Label="Descripción" @bind-Value="@Configuration.Description"/>
+    <NumberField Id="clientListenerPortInput" Label="Puerto de escucha del cliente" @bind-Value="@Configuration.ClientListenerPort"/>
     <LookupField TObject=GameClientDefinition Label="Game Client" @bind-Value="@Configuration.GameClientDefinition"/>
     <div>
-        <label htmlFor="patchVersionInput">Patch-Version</label>
+        <label htmlFor="patchVersionInput">Versión del parche</label>
         <div id="patchVersionInput">
             <div>
-                <span id="major-addon">Major</span>
+                <span id="major-addon">Mayor</span>
             </div>
             <InputNumber id="patchVersionMajorInput" @bind-Value=@this.Configuration.CurrentVersionMajor aria-describedby="major-addon"/>
             <ValidationMessage For="@(() => this.Configuration.CurrentVersionMajor)"/>
         </div>
         <div>
             <div>
-                <span id="minor-addon">Minor</span>
+                <span id="minor-addon">Menor</span>
             </div>
             <InputNumber id="patchVersionMinorInput" @bind-Value=@this.Configuration.CurrentVersionMinor aria-describedby="minor-addon"/>
             <ValidationMessage For="@(() => this.Configuration.CurrentVersionMinor)"/>
         </div>
         <div>
             <div>
-                <span id="patch-addon">Patch</span>
+                <span id="patch-addon">Parche</span>
             </div>
             <InputNumber id="patchVersionPatchInput" @bind-Value=@this.Configuration.CurrentVersionPatch aria-describedby="patch-addon"/>
             <ValidationMessage For="@(() => this.Configuration.CurrentVersionPatch)"/>
         </div>
     </div>
     <div>
-        <label htmlFor="patchAddressInput">Patch-Address</label>
+        <label htmlFor="patchAddressInput">Dirección del parche</label>
         <div id="patchAddressInput">
             <div>
                 <span id="ftp-addon">ftp://</span>
@@ -45,10 +45,10 @@ else
             <InputText @bind-Value=@this.Configuration.PatchAddress aria-describedby="ftp-addon"/>
         </div>
     </div>
-    <BooleanField Id="disconnectOnUnknownPacketInput" Label="Disconnect on unknown packet" @bind-Value="@Configuration.DisconnectOnUnknownPacket"/>
-    <NumberField Id="maximumReceiveSizeInput" Label="Maximum packet size" @bind-Value="@Configuration.MaximumReceiveSize"/>
+    <BooleanField Id="disconnectOnUnknownPacketInput" Label="Desconectar al recibir paquete desconocido" @bind-Value="@Configuration.DisconnectOnUnknownPacket"/>
+    <NumberField Id="maximumReceiveSizeInput" Label="Tamaño máximo de paquete" @bind-Value="@Configuration.MaximumReceiveSize"/>
     <div>
-        <label htmlFor="maxConnectionsPerAddressInput">Maximum connections per address</label>
+        <label htmlFor="maxConnectionsPerAddressInput">Conexiones máximas por dirección</label>
         <div id="maxConnectionsPerAddressInput">
             <div>
                 <span id="connections-addon">
@@ -59,19 +59,19 @@ else
             <ValidationMessage For="@(() => this.Configuration.MaxConnectionsPerAddress)"/>
         </div>
     </div>
-    <NumberField Id="maxConnectionsInput" Label="Maximum connections" @bind-Value="@Configuration.MaxConnections"/>
-    <NumberField Id="listenerBacklogInput" Label="Listener Backlog" @bind-Value="@Configuration.ListenerBacklog"/>
-    <NumberField Id="maxFtpRequestsInput" Label="Maximum ftp requests per session" @bind-Value="@Configuration.MaxFtpRequests"/>
-    <NumberField Id="maxIpRequestsInput" Label="Maximum address requests per session" @bind-Value="@Configuration.MaxIpRequests"/>
-    <NumberField Id="maxServerListRequestsInput" Label="Maximum server list requests per session" @bind-Value="@Configuration.MaxServerListRequests"/>
-    <NumberField Id="timeoutSecondsInput" Label="Connection timeout (seconds)" @bind-Value="@Configuration.TimeoutSeconds"/>
+    <NumberField Id="maxConnectionsInput" Label="Conexiones máximas" @bind-Value="@Configuration.MaxConnections"/>
+    <NumberField Id="listenerBacklogInput" Label="Cola de escucha" @bind-Value="@Configuration.ListenerBacklog"/>
+    <NumberField Id="maxFtpRequestsInput" Label="Solicitudes FTP máximas por sesión" @bind-Value="@Configuration.MaxFtpRequests"/>
+    <NumberField Id="maxIpRequestsInput" Label="Solicitudes de dirección máximas por sesión" @bind-Value="@Configuration.MaxIpRequests"/>
+    <NumberField Id="maxServerListRequestsInput" Label="Solicitudes de lista de servidores máximas por sesión" @bind-Value="@Configuration.MaxServerListRequests"/>
+    <NumberField Id="timeoutSecondsInput" Label="Tiempo de espera de conexión (segundos)" @bind-Value="@Configuration.TimeoutSeconds"/>
 
     <ValidationSummary/>
     <div>
-        <button type="submit" class="primary-button">Save</button>
+        <button type="submit" class="primary-button">Guardar</button>
         @if (this.OnCancel != null)
         {
-            <button type="button" onClick=@this.OnCancel>Cancel</button>
+            <button type="button" onClick=@this.OnCancel>Cancelar</button>
         }
     </div>
 

--- a/src/Web/AdminPanel/Components/ExitGatePicker.razor
+++ b/src/Web/AdminPanel/Components/ExitGatePicker.razor
@@ -3,34 +3,34 @@
 
 <div class="input-group border rounded">
     <div class="input-group-prepend">
-        <span class="" id="targetMapLabel">Target:</span>
+        <span class="" id="targetMapLabel">Destino:</span>
     </div>
     
       @if (!this._maps.Any())
       {
         <div class="form-control border-0 p-0 ml-1">
           <div class="spinner-border text-secondary" role="status">
-            <span class="sr-only">Loading...</span>
+            <span class="sr-only">Cargando...</span>
           </div>
         </div>
       }
       else
       {
         <div class="form-control border-0 p-0 ml-1">
-          <select title="Target map" @onchange=this.OnMapSelectedAsync id="targetMapSelect" autocomplete="off">
+          <select title="Mapa destino" @onchange=this.OnMapSelectedAsync id="targetMapSelect" autocomplete="off">
             @foreach (var map in this._maps)
             {
-              <option value="@map.GetId()" selected=@(object.Equals(this.Map, map))>Map: @map.ToString()</option>
+              <option value="@map.GetId()" selected=@(object.Equals(this.Map, map))>Mapa: @map.ToString()</option>
             }
           </select>
         </div>
         @if (this.Map?.ExitGates.Any() ?? false)
         {
           <div class="form-control border-0 p-0 ml-3">
-            <select title="Gate" @onchange=this.OnGateSelectedAsync id="targetGateSelect" autocomplete="off">
+            <select title="Portal" @onchange=this.OnGateSelectedAsync id="targetGateSelect" autocomplete="off">
               @foreach (var gate in this.Map?.ExitGates ?? [])
               {
-                <option value="@gate.GetId()" selected=@(object.Equals(this.SelectedGate, gate))>Gate: @gate.ToString()</option>
+                <option value="@gate.GetId()" selected=@(object.Equals(this.SelectedGate, gate))>Portal: @gate.ToString()</option>
               }
             </select>
           </div>

--- a/src/Web/AdminPanel/Components/Form/DataTable.razor
+++ b/src/Web/AdminPanel/Components/Form/DataTable.razor
@@ -9,11 +9,11 @@
             @if (this._isLoading)
             {
                 <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                <span class="sr-only">Loading...</span>
+                <span class="sr-only">Cargando...</span>
             }
             else
             {
-                <span>Page @this.Page</span>
+                <span>Página @this.Page</span>
             }
         </button>
         <button disabled="@(!this._hasMoreEntries || this._isLoading)" class="btn btn-sm btn-primary" @onclick=@this.GetNextPageAsync><span class="oi oi-arrow-thick-right" aria-hidden="true" /></button>
@@ -38,7 +38,7 @@
         }
         else if (this._isLoading)
         {
-            <tr>Loading ...</tr>
+            <tr>Cargando ...</tr>
         }
     </tbody>
     <tfoot>


### PR DESCRIPTION
## Summary
- localize server announcements and invasion events with Spanish text
- translate chat command responses and admin panel interface elements into Spanish
- use "baúl" instead of "almacén" for warehouse chat command references

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository access)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82821ac48322936b47444ffca476