### PR TITLE
Send Chaos mix success rate and bonus to client

### DIFF
--- a/src/GameLogic/PlayerActions/Craftings/BaseEventTicketCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/BaseEventTicketCrafting.cs
@@ -37,9 +37,10 @@ public abstract class BaseEventTicketCrafting : BaseItemCraftingHandler
     protected virtual CraftingResult IncorrectMixItemsResult => CraftingResult.IncorrectMixItems;
 
     /// <inheritdoc />
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> itemLinks, out byte successRate)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> itemLinks, out byte successRate, out byte bonusRate)
     {
         successRate = 0;
+        bonusRate = 0;
         itemLinks = new List<CraftingRequiredItemLink>(3);
 
         var item1 = player.TemporaryStorage!.Items.FirstOrDefault(item => item.Definition?.Name == this._requiredEventItemName1);

--- a/src/GameLogic/PlayerActions/Craftings/DinorantCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/DinorantCrafting.cs
@@ -25,9 +25,9 @@ public class DinorantCrafting : SimpleItemCraftingHandler
     }
 
     /// <inheritdoc />
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate, out byte bonusRate)
     {
-        var craftingResult = base.TryGetRequiredItems(player, out items, out successRate);
+        var craftingResult = base.TryGetRequiredItems(player, out items, out successRate, out bonusRate);
         if (craftingResult is null)
         {
             var uniriaLink = items.Where(i => i.ItemRequirement.PossibleItems.Any(i => i.Name == "Horn of Uniria"));

--- a/src/GameLogic/PlayerActions/Craftings/FenrirUpgradeCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/FenrirUpgradeCrafting.cs
@@ -18,9 +18,10 @@ public class FenrirUpgradeCrafting : BaseItemCraftingHandler
     private readonly ItemPriceCalculator _priceCalculator = new();
 
     /// <inheritdoc/>
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRateByItems)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRateByItems, out byte bonusRate)
     {
         successRateByItems = 0;
+        bonusRate = 0;
         items = new List<CraftingRequiredItemLink>(4);
         var inputItems = player.TemporaryStorage!.Items.ToList();
         var itemsLevelAndOption4 = inputItems

--- a/src/GameLogic/PlayerActions/Craftings/FenrirUpgradeCraftingGold.cs
+++ b/src/GameLogic/PlayerActions/Craftings/FenrirUpgradeCraftingGold.cs
@@ -19,9 +19,10 @@ public class FenrirUpgradeCraftingGold : BaseItemCraftingHandler
     private readonly ItemPriceCalculator _priceCalculator = new();
 
     /// <inheritdoc/>
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRateByItems)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRateByItems, out byte bonusRate)
     {
         successRateByItems = 0;
+        bonusRate = 0;
         items = new List<CraftingRequiredItemLink>(4);
         var inputItems = player.TemporaryStorage!.Items.ToList();
         var itemsLevelAndOption4gold = inputItems

--- a/src/GameLogic/PlayerActions/Craftings/GuardianOptionCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/GuardianOptionCrafting.cs
@@ -29,9 +29,9 @@ public class GuardianOptionCrafting : SimpleItemCraftingHandler
     public static byte ItemReference { get; } = 0x88;
 
     /// <inheritdoc />
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate, out byte bonusRate)
     {
-        if (base.TryGetRequiredItems(player, out items, out successRate) is { } error)
+        if (base.TryGetRequiredItems(player, out items, out successRate, out bonusRate) is { } error)
         {
             return error;
         }

--- a/src/GameLogic/PlayerActions/Craftings/MountSeedSphereCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/MountSeedSphereCrafting.cs
@@ -34,9 +34,9 @@ public class MountSeedSphereCrafting : SimpleItemCraftingHandler
     public static byte SocketItemReference { get; } = 0x88;
 
     /// <inheritdoc />
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate, out byte bonusRate)
     {
-        var result = base.TryGetRequiredItems(player, out items, out successRate);
+        var result = base.TryGetRequiredItems(player, out items, out successRate, out bonusRate);
         if (result != default)
         {
             return result;

--- a/src/GameLogic/PlayerActions/Items/IItemCraftingHandler.cs
+++ b/src/GameLogic/PlayerActions/Items/IItemCraftingHandler.cs
@@ -17,8 +17,8 @@ public interface IItemCraftingHandler
     /// </summary>
     /// <param name="player">The mixing player.</param>
     /// <param name="socketSlot">The socket slot index for the <see cref="MountSeedSphereCrafting"/> and <see cref="RemoveSeedSphereCrafting"/>. It's a 0-based index.</param>
-    /// <returns>The crafting result and the resulting item; if there are multiple, only the last one is returned.</returns>
-    ValueTask<(CraftingResult Result, Item? Item)> DoMixAsync(Player player, byte socketSlot);
+    /// <returns>The crafting result, success information and the resulting item; if there are multiple, only the last one is returned.</returns>
+    ValueTask<(CraftingResult Result, Item? Item, byte SuccessRate, byte BonusRate)> DoMixAsync(Player player, byte socketSlot);
 
     /// <summary>
     /// Tries to get the required items for this crafting.
@@ -28,6 +28,7 @@ public interface IItemCraftingHandler
     /// <param name="player">The player.</param>
     /// <param name="items">The items.</param>
     /// <param name="successRateByItems">The success rate by items.</param>
+    /// <param name="bonusRate">The bonus rate.</param>
     /// <returns><c>null</c>, if the required items could be get; Otherwise, the corresponding error is returned.</returns>
-    CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRateByItems);
+    CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRateByItems, out byte bonusRate);
 }

--- a/src/GameLogic/PlayerActions/Items/SimpleItemCraftingHandler.cs
+++ b/src/GameLogic/PlayerActions/Items/SimpleItemCraftingHandler.cs
@@ -27,9 +27,10 @@ public class SimpleItemCraftingHandler : BaseItemCraftingHandler
     }
 
     /// <inheritdoc />
-    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate)
+    public override CraftingResult? TryGetRequiredItems(Player player, out IList<CraftingRequiredItemLink> items, out byte successRate, out byte bonusRate)
     {
         successRate = 0;
+        bonusRate = 0;
         int rate = this._settings.SuccessPercent;
         long totalCraftingPrice = 0;
         items = new List<CraftingRequiredItemLink>(this._settings.RequiredItems.Count);
@@ -117,6 +118,7 @@ public class SimpleItemCraftingHandler : BaseItemCraftingHandler
         }
 
         successRate = (byte)Math.Min(100, rate);
+        bonusRate = (byte)Math.Max(0, successRate - this._settings.SuccessPercent);
 
         return default;
     }

--- a/src/GameLogic/Views/NPC/IShowItemCraftingResultPlugIn.cs
+++ b/src/GameLogic/Views/NPC/IShowItemCraftingResultPlugIn.cs
@@ -13,6 +13,8 @@ public interface IShowItemCraftingResultPlugIn : IViewPlugIn
     /// Shows the crafting result.
     /// </summary>
     /// <param name="result">The crafting result.</param>
+    /// <param name="successRate">The success rate in percent.</param>
+    /// <param name="bonusRate">The additional bonus rate in percent.</param>
     /// <param name="createdItem">The created item.</param>
-    ValueTask ShowResultAsync(CraftingResult result, Item? createdItem);
+    ValueTask ShowResultAsync(CraftingResult result, byte successRate, byte bonusRate, Item? createdItem);
 }

--- a/src/GameServer/MessageHandler/Items/ChaosMixHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/Items/ChaosMixHandlerPlugIn.cs
@@ -38,7 +38,7 @@ internal class ChaosMixHandlerPlugIn : IPacketHandlerPlugIn
             var crafting = this._mixAction.FindAppropriateCraftingByItems(player);
             if (crafting is null)
             {
-                await player.InvokeViewPlugInAsync<IShowItemCraftingResultPlugIn>(p => p.ShowResultAsync(CraftingResult.IncorrectMixItems, null)).ConfigureAwait(false);
+                await player.InvokeViewPlugInAsync<IShowItemCraftingResultPlugIn>(p => p.ShowResultAsync(CraftingResult.IncorrectMixItems, 0, 0, null)).ConfigureAwait(false);
                 return;
             }
 

--- a/src/GameServer/RemoteView/NPC/ShowItemCraftingResultPlugIn.cs
+++ b/src/GameServer/RemoteView/NPC/ShowItemCraftingResultPlugIn.cs
@@ -29,7 +29,7 @@ public class ShowItemCraftingResultPlugIn : IShowItemCraftingResultPlugIn
     }
 
     /// <inheritdoc />
-    public async ValueTask ShowResultAsync(CraftingResult result, Item? createdItem)
+    public async ValueTask ShowResultAsync(CraftingResult result, byte successRate, byte bonusRate, Item? createdItem)
     {
         var itemData = new byte[this._player.ItemSerializer.NeededSpace];
         if (createdItem is { })
@@ -37,7 +37,7 @@ public class ShowItemCraftingResultPlugIn : IShowItemCraftingResultPlugIn
             this._player.ItemSerializer.SerializeItem(itemData, createdItem);
         }
 
-        await this._player.Connection.SendItemCraftingResultAsync(Convert(result), itemData).ConfigureAwait(false);
+        await this._player.Connection.SendItemCraftingResultAsync(Convert(result), successRate, bonusRate, itemData).ConfigureAwait(false);
     }
 
     private static ItemCraftingResult.CraftingResult Convert(CraftingResult result)

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -543,6 +543,8 @@ public static class ConnectionExtensions
     /// </summary>
     /// <param name="connection">The connection.</param>
     /// <param name="changedPlayerId">The changed player id.</param>
+    /// <param name="successRate">The success rate in percent.</param>
+    /// <param name="bonusRate">The additional bonus rate in percent.</param>
     /// <param name="itemData">The item data.</param>
     /// <remarks>
     /// Is sent by the server when: The appearance of a player changed, all surrounding players are informed about it.
@@ -4586,7 +4588,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: After the player requested to execute an item crafting, e.g. at the chaos machine.
     /// Causes reaction on client side: The game client updates the UI to show the resulting item.
     /// </remarks>
-    public static async ValueTask SendItemCraftingResultAsync(this IConnection? connection, ItemCraftingResult.CraftingResult @result, Memory<byte> @itemData)
+    public static async ValueTask SendItemCraftingResultAsync(this IConnection? connection, ItemCraftingResult.CraftingResult @result, byte @successRate, byte @bonusRate, Memory<byte> @itemData)
     {
         if (connection is null)
         {
@@ -4598,6 +4600,8 @@ public static class ConnectionExtensions
             var length = ItemCraftingResultRef.GetRequiredSize(itemData.Length);
             var packet = new ItemCraftingResultRef(connection.Output.GetSpan(length)[..length]);
             packet.Result = @result;
+            packet.SuccessRate = @successRate;
+            packet.BonusRate = @bonusRate;
             @itemData.Span.CopyTo(packet.ItemData);
 
             return packet.Header.Length;

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -22437,11 +22437,29 @@ public readonly struct ItemCraftingResult
     }
 
     /// <summary>
+    /// Gets or sets the success rate.
+    /// </summary>
+    public byte SuccessRate
+    {
+        get => this._data.Span[4];
+        set => this._data.Span[4] = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the bonus rate.
+    /// </summary>
+    public byte BonusRate
+    {
+        get => this._data.Span[5];
+        set => this._data.Span[5] = value;
+    }
+
+    /// <summary>
     /// Gets or sets the item data.
     /// </summary>
     public Span<byte> ItemData
     {
-        get => this._data.Slice(4).Span;
+        get => this._data.Slice(6).Span;
     }
 
     /// <summary>
@@ -22463,7 +22481,7 @@ public readonly struct ItemCraftingResult
     /// </summary>
     /// <param name="itemDataLength">The length in bytes of <see cref="ItemData"/> on which the required size depends.</param>
         
-    public static int GetRequiredSize(int itemDataLength) => itemDataLength + 4;
+    public static int GetRequiredSize(int itemDataLength) => itemDataLength + 6;
 }
 
 

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -8147,6 +8147,16 @@
         </Field>
         <Field>
           <Index>4</Index>
+          <Type>Byte</Type>
+          <Name>SuccessRate</Name>
+        </Field>
+        <Field>
+          <Index>5</Index>
+          <Type>Byte</Type>
+          <Name>BonusRate</Name>
+        </Field>
+        <Field>
+          <Index>6</Index>
           <Type>Binary</Type>
           <Name>ItemData</Name>
         </Field>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -21302,11 +21302,29 @@ public readonly ref struct ItemCraftingResultRef
     }
 
     /// <summary>
+    /// Gets or sets the success rate.
+    /// </summary>
+    public byte SuccessRate
+    {
+        get => this._data[4];
+        set => this._data[4] = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the bonus rate.
+    /// </summary>
+    public byte BonusRate
+    {
+        get => this._data[5];
+        set => this._data[5] = value;
+    }
+
+    /// <summary>
     /// Gets or sets the item data.
     /// </summary>
     public Span<byte> ItemData
     {
-        get => this._data.Slice(4);
+        get => this._data.Slice(6);
     }
 
     /// <summary>
@@ -21328,7 +21346,7 @@ public readonly ref struct ItemCraftingResultRef
     /// </summary>
     /// <param name="itemDataLength">The length in bytes of <see cref="ItemData"/> on which the required size depends.</param>
         
-    public static int GetRequiredSize(int itemDataLength) => itemDataLength + 4;
+    public static int GetRequiredSize(int itemDataLength) => itemDataLength + 6;
 }
 
 

--- a/tests/MUnique.OpenMU.Network.Packets.Tests/ServerToClientPacketTests.cs
+++ b/tests/MUnique.OpenMU.Network.Packets.Tests/ServerToClientPacketTests.cs
@@ -4666,7 +4666,7 @@ public class PacketStructureTests
         // Test GetRequiredSize method with sample data
         const int testBinaryLength = 10;
         var calculatedSize = ItemCraftingResultRef.GetRequiredSize(testBinaryLength);
-        var expectedMinSize = testBinaryLength + 4;
+        var expectedMinSize = testBinaryLength + 6;
         
         Assert.That(calculatedSize, Is.GreaterThanOrEqualTo(expectedMinSize), 
             "GetRequiredSize calculation incorrect for binary field");


### PR DESCRIPTION
## Summary
- include success and bonus rates when sending item crafting results
- expose success info through crafting handler and views
- extend ItemCraftingResult packet with success and bonus fields

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1091f8488322b872bcb2e0c90eeb