### PR TITLE
refactor: remove plugin inheritance from summon config

### DIFF
--- a/src/GameLogic/PlayerActions/Skills/TargetedSkillDefaultPlugin.cs
+++ b/src/GameLogic/PlayerActions/Skills/TargetedSkillDefaultPlugin.cs
@@ -132,7 +132,7 @@ public class TargetedSkillDefaultPlugin : TargetedSkillPluginBase
                 defaultDefinition = mappedDefinition;
             }
 
-            var summonPlugin = player.GameContext.PlugInManager.GetPlugIn<ISummonConfigurationPlugIn>();
+            var summonPlugin = player.GameContext.PlugInManager.GetPlugInPoint<ISummonConfigurationPlugIn>();
             var monsterDefinition = summonPlugin?.CreateSummonMonsterDefinition(player, skill, defaultDefinition) ?? defaultDefinition;
 
             if (monsterDefinition is not null)

--- a/src/GameLogic/PlugIns/ISummonConfigurationPlugIn.cs
+++ b/src/GameLogic/PlugIns/ISummonConfigurationPlugIn.cs
@@ -13,7 +13,7 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 [Guid("C1E5C063-9CF8-4FE7-9C0F-4BB6387E3C27")]
 [PlugInPoint("Summon configuration", "Provides monster definitions for summon skills.")]
-public interface ISummonConfigurationPlugIn : IPlugIn
+public interface ISummonConfigurationPlugIn
 {
     /// <summary>
     /// Creates the monster definition which should be used for the summon skill.


### PR DESCRIPTION
## Summary
- remove `IPlugIn` inheritance from `ISummonConfigurationPlugIn`
- retrieve summon configuration using `GetPlugInPoint`

## Testing
- `apt-get update` *(fails: repository not signed / 403 errors)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*
- `dotnet build --configuration Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf52db89b08322b1ce867459332bd7