### PR TITLE
Add plugin for customizable summoned monsters

### DIFF
--- a/src/GameLogic/PlayerActions/Skills/TargetedSkillDefaultPlugin.cs
+++ b/src/GameLogic/PlayerActions/Skills/TargetedSkillDefaultPlugin.cs
@@ -10,6 +10,7 @@ using MUnique.OpenMU.GameLogic.NPC;
 using MUnique.OpenMU.GameLogic.PlugIns;
 using MUnique.OpenMU.GameLogic.Views.World;
 using MUnique.OpenMU.PlugIns;
+using MUnique.OpenMU.DataModel.Configuration;
 
 /// <summary>
 /// Action to perform a skill which is explicitly aimed to a target.
@@ -124,8 +125,17 @@ public class TargetedSkillDefaultPlugin : TargetedSkillPluginBase
         var effectApplied = false;
         if (skill.SkillType == SkillType.SummonMonster)
         {
+            MonsterDefinition? defaultDefinition = null;
             if (SummonSkillToMonsterMapping.TryGetValue(skill.Number, out var monsterNumber)
-                && player.GameContext.Configuration.Monsters.FirstOrDefault(m => m.Number == monsterNumber) is { } monsterDefinition)
+                && player.GameContext.Configuration.Monsters.FirstOrDefault(m => m.Number == monsterNumber) is { } mappedDefinition)
+            {
+                defaultDefinition = mappedDefinition;
+            }
+
+            var summonPlugin = player.GameContext.PlugInManager.GetPlugIn<ISummonConfigurationPlugIn>();
+            var monsterDefinition = summonPlugin?.CreateSummonMonsterDefinition(player, skill, defaultDefinition) ?? defaultDefinition;
+
+            if (monsterDefinition is not null)
             {
                 await player.CreateSummonedMonsterAsync(monsterDefinition).ConfigureAwait(false);
             }
@@ -249,6 +259,11 @@ public class TargetedSkillDefaultPlugin : TargetedSkillPluginBase
         {
             if (skill.SkillType == SkillType.DirectHit || skill.SkillType == SkillType.CastleSiegeSkill)
             {
+                if (target is Monster { SummonedBy: { } owner } && owner == player)
+                {
+                    continue;
+                }
+
                 if (player.Attributes![Stats.AmmunitionConsumptionRate] > player.Attributes[Stats.AmmunitionAmount])
                 {
                     break;

--- a/src/GameLogic/PlugIns/ExampleSummonConfigurationPlugIn.cs
+++ b/src/GameLogic/PlugIns/ExampleSummonConfigurationPlugIn.cs
@@ -1,0 +1,44 @@
+// <copyright file="ExampleSummonConfigurationPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Linq;
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Example plug-in which replaces the default goblin summon with a Tantal and adjusts its stats.
+/// </summary>
+[Guid("27F0E8B5-61D3-4FB4-96F2-8B1ED2BB8C54")]
+[PlugIn(nameof(ExampleSummonConfigurationPlugIn), "Example plug-in which replaces the goblin summon with a Tantal and adjusts its stats.")]
+public class ExampleSummonConfigurationPlugIn : ISummonConfigurationPlugIn
+{
+    /// <inheritdoc />
+    public MonsterDefinition? CreateSummonMonsterDefinition(Player player, Skill skill, MonsterDefinition? defaultDefinition)
+    {
+        if (skill.Number != 30) // goblin summon
+        {
+            return defaultDefinition;
+        }
+
+        var baseDefinition = player.GameContext.Configuration.Monsters.FirstOrDefault(m => m.Number == 58); // Tantal
+        if (baseDefinition is null)
+        {
+            return defaultDefinition;
+        }
+
+        var clone = baseDefinition.Clone(player.GameContext.Configuration);
+        var healthAttribute = clone.Attributes.FirstOrDefault(a => a.AttributeDefinition == Stats.MaximumHealth);
+        if (healthAttribute is not null)
+        {
+            healthAttribute.Value *= 2;
+        }
+
+        return clone;
+    }
+}
+

--- a/src/GameLogic/PlugIns/ISummonConfigurationPlugIn.cs
+++ b/src/GameLogic/PlugIns/ISummonConfigurationPlugIn.cs
@@ -1,0 +1,27 @@
+// <copyright file="ISummonConfigurationPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Provides monster definitions for summon skills and allows to adjust their stats.
+/// </summary>
+[Guid("C1E5C063-9CF8-4FE7-9C0F-4BB6387E3C27")]
+[PlugInPoint("Summon configuration", "Provides monster definitions for summon skills.")]
+public interface ISummonConfigurationPlugIn
+{
+    /// <summary>
+    /// Creates the monster definition which should be used for the summon skill.
+    /// </summary>
+    /// <param name="player">The summoning player.</param>
+    /// <param name="skill">The used summon skill.</param>
+    /// <param name="defaultDefinition">The default monster definition which would be used without this plug-in.</param>
+    /// <returns>The monster definition which should be summoned, or <c>null</c> if the default mapping should be used.</returns>
+    MonsterDefinition? CreateSummonMonsterDefinition(Player player, Skill skill, MonsterDefinition? defaultDefinition);
+}
+

--- a/src/GameLogic/PlugIns/SelfDefensePlugIn.cs
+++ b/src/GameLogic/PlugIns/SelfDefensePlugIn.cs
@@ -43,9 +43,9 @@ public class SelfDefensePlugIn : IPeriodicTaskPlugIn, IAttackableGotHitPlugIn, I
     /// <inheritdoc />
     public void AttackableGotHit(IAttackable attackable, IAttacker attacker, HitInfo hitInfo)
     {
-        var defender = attackable as Player ?? (attackable as Monster)?.SummonedBy;
-        var attackerPlayer = attacker as Player ?? (attackable as Monster)?.SummonedBy;
-        if (defender is null || attackerPlayer is null)
+        var defender = attackable as Player ?? (attackable as ISummonable)?.SummonedBy;
+        var attackerPlayer = attacker as Player ?? (attacker as ISummonable)?.SummonedBy;
+        if (defender is null || attackerPlayer is null || defender == attackerPlayer)
         {
             return;
         }

--- a/tests/MUnique.OpenMU.Tests/SelfDefensePlugInTest.cs
+++ b/tests/MUnique.OpenMU.Tests/SelfDefensePlugInTest.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using Moq;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.DataModel.Configuration;
+
+namespace MUnique.OpenMU.Tests;
+
+/// <summary>
+/// Tests for <see cref="SelfDefensePlugIn"/>.
+/// </summary>
+[TestFixture]
+public class SelfDefensePlugInTest
+{
+    /// <summary>
+    /// Ensures that hitting an own summon doesn't start self-defense.
+    /// </summary>
+    [Test]
+    public async ValueTask OwnSummonHitDoesNotStartSelfDefenseAsync()
+    {
+        var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
+
+        var summonMock = new Mock<IAttackable>();
+        var summonable = summonMock.As<ISummonable>();
+        summonable.Setup(s => s.SummonedBy).Returns(player);
+        summonable.Setup(s => s.Definition).Returns(new MonsterDefinition());
+
+        var plugIn = new SelfDefensePlugIn();
+        plugIn.AttackableGotHit(summonMock.Object, player, new HitInfo(1, 0, DamageAttributes.Undefined));
+
+        Assert.That(player.GameContext.SelfDefenseState, Is.Empty);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow single plugin to configure all summon skills
- Use summon configuration plugin before default skill-to-monster mapping
- Provide example plugin mapping goblin summon to a stronger Tantal
- Ignore direct-hit skills that target a player's own summon
- Avoid self-defense triggering when attacking your own summon
- Add unit test to ensure self-defense stays inactive on self-summon hits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3d7596088322b96f5239657b1097